### PR TITLE
Add versioned YAML schema engine

### DIFF
--- a/src/dbt_osmosis/cli/main.py
+++ b/src/dbt_osmosis/cli/main.py
@@ -54,6 +54,7 @@ def cli() -> None:
 def test_llm_connection(llm_client=None) -> None:
     """Test the connection to the LLM client."""
     import os
+
     from dbt_osmosis.core.llm import get_llm_client
 
     llm_client = os.getenv("LLM_PROVIDER")
@@ -191,6 +192,12 @@ def yaml_opts(func: t.Callable[P, T]) -> t.Callable[P, T]:
         "--disable-introspection",
         is_flag=True,
         help="Allows running the program without a database connection, it is recommended to use the --catalog-path option if using this.",
+    )
+    @click.option(
+        "--yaml-schema-version",
+        type=click.Choice(["legacy", "1.10", "auto"], case_sensitive=False),
+        default="legacy",
+        help="YAML schema version to use when reading and writing docs.",
     )
     @functools.wraps(func)
     def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:

--- a/src/dbt_osmosis/core/inheritance.py
+++ b/src/dbt_osmosis/core/inheritance.py
@@ -63,7 +63,12 @@ def _get_node_yaml(context: t.Any, member: ResultNode) -> MappingProxyType[str, 
         path = project_dir.joinpath(member.original_file_path)
         sources = t.cast(
             list[dict[str, t.Any]],
-            _read_yaml(context.yaml_handler, context.yaml_handler_lock, path).get("sources", []),
+            _read_yaml(
+                context.yaml_handler,
+                context.yaml_handler_lock,
+                path,
+                context.schema_engine,
+            ).get("sources", []),
         )
         source = _find_first(sources, lambda s: s["name"] == member.source_name, {})
         tables = source.get("tables", [])
@@ -78,7 +83,12 @@ def _get_node_yaml(context: t.Any, member: ResultNode) -> MappingProxyType[str, 
         section = f"{member.resource_type}s"
         models = t.cast(
             list[dict[str, t.Any]],
-            _read_yaml(context.yaml_handler, context.yaml_handler_lock, path).get(section, []),
+            _read_yaml(
+                context.yaml_handler,
+                context.yaml_handler_lock,
+                path,
+                context.schema_engine,
+            ).get(section, []),
         )
         maybe_doc = _find_first(models, lambda model: model["name"] == member.name)
         if maybe_doc is not None:

--- a/src/dbt_osmosis/core/osmosis.py
+++ b/src/dbt_osmosis/core/osmosis.py
@@ -115,6 +115,7 @@ def commit_yamls(context: YamlRefactorContext) -> None:
     _commit_yamls_impl(
         yaml_handler=context.yaml_handler,
         yaml_handler_lock=context.yaml_handler_lock,
+        engine=context.schema_engine,
         dry_run=context.settings.dry_run,
         mutation_tracker=context.register_mutations,
     )

--- a/src/dbt_osmosis/core/schema/__init__.py
+++ b/src/dbt_osmosis/core/schema/__init__.py
@@ -1,3 +1,4 @@
+from dbt_osmosis.core.schema.formats import get_engine
 from dbt_osmosis.core.schema.parser import *  # noqa: F403
 from dbt_osmosis.core.schema.reader import *  # noqa: F403
 from dbt_osmosis.core.schema.writer import *  # noqa: F403
@@ -8,4 +9,5 @@ __all__ = [
     "_write_yaml",  # noqa: F405
     "commit_yamls",  # noqa: F405
     "_YAML_BUFFER_CACHE",  # noqa: F405
+    "get_engine",
 ]

--- a/src/dbt_osmosis/core/schema/formats/__init__.py
+++ b/src/dbt_osmosis/core/schema/formats/__init__.py
@@ -1,2 +1,22 @@
-# Format handlers will be imported here once created
-__all__: list[str] = []
+from __future__ import annotations
+
+from .base import SchemaEngine
+from .v1_10 import V110Engine
+from .v1_legacy import LegacyEngine
+
+_REGISTRY = {
+    "legacy": LegacyEngine(),
+    "1.10": V110Engine(),
+}
+
+
+def get_engine(version: str) -> SchemaEngine:
+    if version not in _REGISTRY:
+        raise ValueError(f"Unknown YAML schema version: {version}")
+    return _REGISTRY[version]
+
+
+__all__ = [
+    "SchemaEngine",
+    "get_engine",
+]

--- a/src/dbt_osmosis/core/schema/formats/base.py
+++ b/src/dbt_osmosis/core/schema/formats/base.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import typing as t
+
+
+class SchemaEngine(t.Protocol):
+    """Protocol for schema engines that handle YAML format differences."""
+
+    version: str
+
+    def load(self, doc: dict[str, t.Any]) -> dict[str, t.Any]:
+        """Normalize a raw YAML document to the internal representation."""
+        ...
+
+    def dump(self, doc: dict[str, t.Any]) -> dict[str, t.Any]:
+        """Convert an internal representation back to a YAML document."""
+        ...
+
+    def migrate(self, doc: dict[str, t.Any]) -> dict[str, t.Any]:
+        """Migrate a legacy YAML document to this engine's format."""
+        ...

--- a/src/dbt_osmosis/core/schema/formats/v1_10.py
+++ b/src/dbt_osmosis/core/schema/formats/v1_10.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import copy
+import typing as t
+
+
+class V110Engine:
+    """Schema engine that moves certain keys under a config block."""
+
+    version = "1.10"
+    MOVED_KEYS = {"meta", "tags", "docs", "group", "access", "freshness"}
+
+    def load(self, doc: dict[str, t.Any]) -> dict[str, t.Any]:
+        data = copy.deepcopy(doc)
+        for section in ("models", "sources", "seeds", "snapshots"):
+            for entry in data.get(section, []):
+                self._pull_config(entry)
+                for col in entry.get("columns", []):
+                    self._pull_column_config(col)
+                if section == "sources":
+                    for tbl in entry.get("tables", []):
+                        self._pull_config(tbl)
+                        for col in tbl.get("columns", []):
+                            self._pull_column_config(col)
+        return data
+
+    def dump(self, doc: dict[str, t.Any]) -> dict[str, t.Any]:
+        data = copy.deepcopy(doc)
+        for section in ("models", "sources", "seeds", "snapshots"):
+            for entry in data.get(section, []):
+                self._push_config(entry)
+                for col in entry.get("columns", []):
+                    self._push_column_config(col)
+                if section == "sources":
+                    for tbl in entry.get("tables", []):
+                        self._push_config(tbl)
+                        for col in tbl.get("columns", []):
+                            self._push_column_config(col)
+        return data
+
+    def migrate(self, doc: dict[str, t.Any]) -> dict[str, t.Any]:
+        """Migrate a legacy document to v1.10 layout."""
+        return self.dump(doc)
+
+    def _pull_config(self, entry: dict[str, t.Any]) -> None:
+        cfg = entry.pop("config", {})
+        meta = cfg.pop("meta", None)
+        if meta is not None:
+            entry.setdefault("meta", meta)
+        for k in self.MOVED_KEYS - {"meta"}:
+            if k in cfg:
+                entry.setdefault(k, cfg.pop(k))
+        if cfg:
+            entry["config"] = cfg
+
+    def _pull_column_config(self, col: dict[str, t.Any]) -> None:
+        cfg = col.pop("config", {})
+        meta = cfg.pop("meta", None)
+        if meta is not None:
+            col.setdefault("meta", meta)
+        if cfg:
+            col["config"] = cfg
+
+    def _push_config(self, entry: dict[str, t.Any]) -> None:
+        cfg = entry.get("config", {})
+        meta = entry.pop("meta", None)
+        if meta is not None:
+            cfg.setdefault("meta", meta)
+        for k in self.MOVED_KEYS - {"meta"}:
+            val = entry.pop(k, None)
+            if val is not None:
+                cfg.setdefault(k, val)
+        if cfg:
+            entry["config"] = cfg
+        else:
+            entry.pop("config", None)
+
+    def _push_column_config(self, col: dict[str, t.Any]) -> None:
+        cfg = col.get("config", {})
+        meta = col.pop("meta", None)
+        if meta is not None:
+            cfg.setdefault("meta", meta)
+        if cfg:
+            col["config"] = cfg
+        else:
+            col.pop("config", None)
+
+
+__all__ = ["V110Engine"]

--- a/src/dbt_osmosis/core/schema/formats/v1_legacy.py
+++ b/src/dbt_osmosis/core/schema/formats/v1_legacy.py
@@ -1,21 +1,58 @@
 from __future__ import annotations
 
+import copy
 import typing as t
 
 
 class LegacyEngine:
-    """Pass-through engine for legacy YAML layout."""
+    """Schema engine for the legacy YAML layout used prior to dbt 1.10."""
 
     version = "legacy"
+    MOVED_KEYS = {"meta", "tags", "docs", "group", "access", "freshness"}
 
     def load(self, doc: dict[str, t.Any]) -> dict[str, t.Any]:
-        return doc
+        """Normalize YAML that may contain ``config`` blocks to the legacy shape."""
+        data = t.cast(dict[str, t.Any], copy.deepcopy(doc))
+        for section in ("models", "sources", "seeds", "snapshots"):
+            for entry in data.get(section, []):
+                self._pull_config(entry)
+                for col in entry.get("columns", []):
+                    self._pull_column_config(col)
+                if section == "sources":
+                    for tbl in entry.get("tables", []):
+                        self._pull_config(tbl)
+                        for col in tbl.get("columns", []):
+                            self._pull_column_config(col)
+        return data
 
     def dump(self, doc: dict[str, t.Any]) -> dict[str, t.Any]:
-        return doc
+        """Return YAML in the legacy layout (no ``config`` wrappers)."""
+        # ``load`` already returns the document with config keys pulled up, so we
+        # reuse it to ensure any stray config blocks are flattened.
+        return self.load(doc)
 
     def migrate(self, doc: dict[str, t.Any]) -> dict[str, t.Any]:
-        return doc
+        """Alias for ``load`` allowing v1.10 documents to be downgraded."""
+        return self.load(doc)
+
+    def _pull_config(self, entry: dict[str, t.Any]) -> None:
+        cfg = entry.pop("config", {})
+        meta = cfg.pop("meta", None)
+        if meta is not None:
+            entry.setdefault("meta", meta)
+        for k in self.MOVED_KEYS - {"meta"}:
+            if k in cfg:
+                entry.setdefault(k, cfg.pop(k))
+        if cfg:
+            entry["config"] = cfg
+
+    def _pull_column_config(self, col: dict[str, t.Any]) -> None:
+        cfg = col.pop("config", {})
+        meta = cfg.pop("meta", None)
+        if meta is not None:
+            col.setdefault("meta", meta)
+        if cfg:
+            col["config"] = cfg
 
 
 __all__ = ["LegacyEngine"]

--- a/src/dbt_osmosis/core/schema/formats/v1_legacy.py
+++ b/src/dbt_osmosis/core/schema/formats/v1_legacy.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import typing as t
+
+
+class LegacyEngine:
+    """Pass-through engine for legacy YAML layout."""
+
+    version = "legacy"
+
+    def load(self, doc: dict[str, t.Any]) -> dict[str, t.Any]:
+        return doc
+
+    def dump(self, doc: dict[str, t.Any]) -> dict[str, t.Any]:
+        return doc
+
+    def migrate(self, doc: dict[str, t.Any]) -> dict[str, t.Any]:
+        return doc
+
+
+__all__ = ["LegacyEngine"]

--- a/src/dbt_osmosis/core/settings.py
+++ b/src/dbt_osmosis/core/settings.py
@@ -63,6 +63,9 @@ class YamlRefactorSettings:
     create_catalog_if_not_exists: bool = False
     """Generate the catalog.json for the project if it doesn't exist and use it for introspective queries."""
 
+    yaml_schema_version: str = "legacy"
+    """YAML schema version to use when reading/writing docs."""
+
 
 @dataclass
 class YamlRefactorContext:
@@ -91,6 +94,8 @@ class YamlRefactorContext:
         "Not documented",
         "Undefined",
     )
+
+    schema_engine: t.Any = field(init=False)
 
     _mutation_count: int = field(default=0, init=False)
     _catalog: CatalogResults | None = field(default=None, init=False)
@@ -177,6 +182,9 @@ class YamlRefactorContext:
         self.yaml_handler = create_yaml_instance()
         for setting, val in self.yaml_settings.items():
             setattr(self.yaml_handler, setting, val)
+        from dbt_osmosis.core.schema.formats import get_engine
+
+        self.schema_engine = get_engine(self.settings.yaml_schema_version)
         self.pool._max_workers = self.project.runtime_cfg.threads
         logger.info(
             ":notebook: Osmosis ThreadPoolExecutor max_workers synced with dbt => %s",

--- a/src/dbt_osmosis/core/sync_operations.py
+++ b/src/dbt_osmosis/core/sync_operations.py
@@ -127,7 +127,10 @@ def sync_node_to_yaml(
         current_path = get_target_yaml_path(context, node)
 
     doc: dict[str, t.Any] = _read_yaml(
-        context.yaml_handler, context.yaml_handler_lock, current_path
+        context.yaml_handler,
+        context.yaml_handler_lock,
+        current_path,
+        context.schema_engine,
     )
     if not doc:
         doc = {"version": 2}
@@ -247,6 +250,7 @@ def sync_node_to_yaml(
             context.yaml_handler_lock,
             current_path,
             doc,
-            context.settings.dry_run,
-            context.register_mutations,
+            engine=context.schema_engine,
+            dry_run=context.settings.dry_run,
+            mutation_tracker=context.register_mutations,
         )

--- a/tests/core/test_sync_operations.py
+++ b/tests/core/test_sync_operations.py
@@ -63,6 +63,7 @@ def test_commit_yamls_no_write(yaml_context: YamlRefactorContext):
     commit_yamls(
         yaml_handler=yaml_context.yaml_handler,
         yaml_handler_lock=yaml_context.yaml_handler_lock,
+        engine=yaml_context.schema_engine,
         dry_run=yaml_context.settings.dry_run,
         mutation_tracker=yaml_context.register_mutations,
     )


### PR DESCRIPTION
## Summary
- implement basic versioned schema engines and registry
- wire schema engine into YAML read/write utilities
- expose new --yaml-schema-version CLI option
- store schema engine in refactor context
- adjust tests for new API

## Testing
- `uvx ruff check --fix --select I`
- `uvx ruff format --preview`
- `uvx ruff check`
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_6880ec691ea4832c8a8e9b124a69f78c